### PR TITLE
Feat: Separate the QAs from the developer ranking

### DIFF
--- a/src/commits.ts
+++ b/src/commits.ts
@@ -2,7 +2,7 @@ import {AggregateCommits, GraphQLCommit, GraphQLCommitsResponse} from "./types";
 import {sleep, retryWithBackoff} from "./utils";
 import {COMMITS_CACHE} from "./cache";
 import fetch from "node-fetch";
-import { GITHUB_GRAPHQL_API} from "./constants";
+import { GITHUB_GRAPHQL_API, EXCLUDED_FROM_RANKINGS} from "./constants";
 
 const COMMITS_QUERY = `
     query($repoOwner: String!, $repository:String!, $since: GitTimestamp, $until: GitTimestamp, $cursor: String) {
@@ -150,6 +150,12 @@ export const aggregateCommits = (commits: GraphQLCommit[]): Record<string, Aggre
         if (author === "Unknown" && commit.author) {
             author = commit.author.name ?? "Unknown";
         }
+        
+        // Skip excluded users from rankings  
+        if (EXCLUDED_FROM_RANKINGS.has(author.toLowerCase())) {
+            return;
+        }
+        
         const record: AggregateCommits = aggregate[author] ?? {
             additions: 0,
             deletions: 0,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,32 @@ export const DAYS_IN_INTERVAL = 5;
 export const BLACKLISTED_CODE_USERS = new Set<string>([
     "waqas", "fullstack900", "ghost", "dependabot[bot]", "unknown", "kaikrmen", "metalmagno", "aovallegalan",
     "shedeed1","snyk-bot", "amlingad", "brennenhamilton", "copilot-pull-request-reviewer"]);
+
+// Users excluded from all contributor rankings (system accounts and non-evaluatable users)
+export const EXCLUDED_FROM_RANKINGS = new Set<string>([
+    "yamilachan",
+    "edwardzabalaf", 
+    "github-actions",
+    "github-actions[bot]",
+    "esteban199",
+    "copilot",
+    "copilot-swe-agent"
+]);
+
+// QA team users (quality assurance engineers)
+export const QA_USERS = new Set<string>([
+    "augustoaf13",
+    "juansebasmarin", 
+    "nicolas-toledo",
+    "altaciosthedev",
+    "anjelysleal"
+]);
+
+// Function to determine if a user is QA (case-insensitive)
+export const isQAUser = (username: string): boolean => {
+    return QA_USERS.has(username.toLowerCase());
+};
+
 export const AUTHOR_ALIAS_MAP = new Map<string, string>([
     ["yeferson hidalgo", "memimint"],
     ["jonathan miles", "jonmiles"],


### PR DESCRIPTION
…adding separate rankings for QA and Dev teams, and updating email content to reflect these changes. Introduce a new constant for excluded users and refactor ranking logic to accommodate team-specific metrics.
https://github.com/rapid-recovery-agency-inc/insightt-tickets/issues/739